### PR TITLE
removing library(car) & small stuff

### DIFF
--- a/extraTutorials/tutorialBonusContent/Functions_and_correlations.Rmd
+++ b/extraTutorials/tutorialBonusContent/Functions_and_correlations.Rmd
@@ -13,55 +13,60 @@ output:
 During the tutorial on Wednesday, we had a couple requests for extra things people would like to cover. The main ones were writing your own function and correlations + correlation tables. These are also great topics for future R club meetings, but here's a brief overview of these two things.
 
 ```{r}
-
 #First some set up:
 
-#install.packages("car")
-library(car)
+if (!require(corrplot)) {
+  install.packages("corrplot")
+} else {
+  require(corrplot)
+}
 
-#install.packages("corrplot")
-library(corrplot)
-
-library(tidyverse)
-
-
-
+if (!require(tidyverse)) {
+  install.packages("tidyverse")
+} else {
+  require(tidyverse)
+}
 ```
+
 ### Make your own function
 
 Any function you make will have basically the same format, and will be created using the `function()` function:
 
+```{r, eval = FALSE}
 functionName <- function(argument1, argument2, ...) {
-  Function code
-  Function code
-  More Function code
-  return(Return Value)
+  function_code
+  function_code
+  more_function_code
+  return(output_value)
 }
+```
 
-The body of the function will come between the curly brackets, and the last line of the body should be whatever the function is going to spit out at the end (if anything).
+The body of the function will come between the curly brackets, and the last line of the body should be whatever the function is going to spit out at the end.
 
-Let's say you're collaborating with a british colleague who is sending you data they are collecting so that you can analyze it. One of the variables is the temperature of the room where the experiment took place, in celcius. Your colleague is constantly sending you new data as they collect it, but you'd really rather work with values in farenheit. We can create a function to do the conversion for you so you don't have to look up the formula every time.
+Let's say you're collaborating with a British colleague who is sending you data they are collecting so that you can analyze it. One of the variables is the temperature of the room where the experiment took place, in Celsius. Your colleague is constantly sending you new data as they collect it, but you'd really rather work with values in Fahrenheit. We can create a function to do the conversion for you so you don't have to look up the formula every time.
 
 ```{r}
 
-# Here's the function, with a formula I found on the internet. The input argument is the temperature in Celcius. A variable called TempF is created within the function, which is the result of taking TempC and transforming it. We then return the value of TempF
+# Here's the function, with a formula I found on the internet. The input argument is the temperature in Celsius. A variable called TempF is created within the function, which is the result of taking TempC and transforming it. We then return the value of TempF
 
 C2F <- function(TempC) {
   TempF <- TempC * 1.8 + 32
   return(TempF)
 }
+```
 
-# What's 20 degrees celcius in farenheit?
+```{r}
+# What's 20 degrees Celsius in Fahrenheit?
 
 C2F(20)
+```
 
-# What are all these values in farenheit?
+```{r}
+# What are all these values in Fahrenheit?
 
 oldTemps <- c(19, 27, 0, 66, 37)
 
 C2F(oldTemps)
-
-
 ```
 
 
@@ -69,27 +74,27 @@ C2F(oldTemps)
 
 ```{r}
 
-# Here I'm just using the packages "car", which has a handy build in dataset called mtcars full of nice continuous variables we can correlate. 
+# R has a handy build in dataset called mtcars full of nice continuous variables we can correlate. 
 data("mtcars")
 head(mtcars)
 
 # Select only the variables you're interested in correlating
-mtcars <- mtcars %>% 
+our_mtcars <- mtcars %>% 
   select(mpg, cyl, gear, vs)
 
-# cor() is the basic R function for computing correlations. As arguments, it needs two vectors of the same length, or a dataframe with more than two vectors. 
+# cor() is the basic R function for computing correlations. As arguments, it needs two vectors of the same length, or a dataframe with at least two columns. 
 
 # Inputing two vectors produces one correlation coefficient.
-cor(mtcars$mpg, mtcars$cyl)
+cor(our_mtcars$mpg, our_mtcars$cyl)
 
 # Inputting a dataframe of multiple columns creates a correlation matrix
-cor(mtcars)
+cor(our_mtcars)
 
 # However, these are rather ugly matrices. For nicer ones, I recommend the corrplot package.
 # The main function is corrplot(), which takes as inputs a correlation matrix and a 'method'.
 
 # First, save your correlation matrix
-CarCor <- cor(mtcars)
+CarCor <- cor(our_mtcars)
 
 corrplot(CarCor, method="circle")
 
@@ -103,5 +108,4 @@ corrplot(CarCor, method="ellipse", type="upper",
 # to get really fancy, try corrplot.mixed instead. This lets you vizualize in multiple ways.
 
 corrplot.mixed(CarCor)
-
 ```


### PR DESCRIPTION
Suggesting the following edits:

- remove `library(car)` because `mtcars` actually comes with base R
- assigning the `select()`-ed subset of `mtcars` to `our_mtcars` to avoid namespace overloading, just as best practice
- small typos and syntax stuff (e.g. breaking code chunks with multiple console outputs so there's one output per chunk)

Please feel free to accept all, some, or none of these suggestions. thank you!